### PR TITLE
feat: add agent Docker image support and update documentation

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -1,0 +1,93 @@
+name: Agent Docker Image CI/CD
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+jobs:
+  detect-agent-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has_agent_changes: ${{ steps.detect.outputs.has_agent_changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes under agent/
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PREV_TAG=$(git describe --tags --abbrev=0 "${GITHUB_SHA}^" 2>/dev/null || true)
+          if [[ -n "${PREV_TAG}" ]]; then
+            RANGE="${PREV_TAG}..${GITHUB_SHA}"
+          else
+            RANGE="${GITHUB_SHA}^..${GITHUB_SHA}"
+          fi
+
+          echo "Using diff range: ${RANGE}"
+
+          if git diff --name-only "${RANGE}" | grep -q '^agent/'; then
+            echo "has_agent_changes=true" >> "${GITHUB_OUTPUT}"
+            echo "Detected changes in agent/"
+          else
+            echo "has_agent_changes=false" >> "${GITHUB_OUTPUT}"
+            echo "No changes detected in agent/"
+          fi
+
+  build-and-push-agent:
+    runs-on: ubuntu-latest
+    needs: detect-agent-changes
+    if: needs.detect-agent-changes.outputs.has_agent_changes == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags and labels) for agent Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/powerbeacon-agent
+            ${{ secrets.DOCKERHUB_USERNAME }}/powerbeacon-agent
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push agent image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./agent
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Docker Image CI/CD](https://github.com/kotsiossp97/powerbeacon/actions/workflows/docker-image.yml/badge.svg)](https://github.com/kotsiossp97/powerbeacon/actions/workflows/docker-image.yml)
+[![Agent Docker Image CI/CD](https://github.com/kotsiossp97/powerbeacon/actions/workflows/agent-image.yml/badge.svg)](https://github.com/kotsiossp97/powerbeacon/actions/workflows/agent-image.yml)
 [![Documentation](https://github.com/kotsiossp97/powerbeacon/actions/workflows/docs.yml/badge.svg)](https://github.com/kotsiossp97/powerbeacon/actions/workflows/docs.yml)
 ![Docker Pulls](https://img.shields.io/docker/pulls/kotsiossp97/powerbeacon?style=flat&logo=docker&label=Docker%20Pulls&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fkotsiossp97%2Fpowerbeacon)
 ![Docker Image Size](https://img.shields.io/docker/image-size/kotsiossp97/powerbeacon?logo=docker&label=Image%20Size)
@@ -83,6 +84,13 @@ make run
 ## Development note
 
 The schema has been refactored directly for the current development phase. If you still have a database from the older single-agent device model, reset it before starting this version of the app.
+
+## Agent container image
+
+- Dedicated image: `kotsiossp97/powerbeacon-agent`
+- Multi-architecture support: `linux/amd64` and `linux/arm64`
+- Built and published by the dedicated GitHub Actions workflow in `.github/workflows/agent-image.yml`
+- On tag pushes, the workflow builds the agent image only when there are changes under `agent/`
 
 ## Key API routes
 

--- a/agent/DEVELOPMENT.md
+++ b/agent/DEVELOPMENT.md
@@ -66,6 +66,7 @@ make run
 chmod +x build.sh
 ./build.sh all          # Build all platforms
 ./build.sh local        # Build for current platform
+./build.sh docker-cross # Build using TARGETOS/TARGETARCH from env (Buildx use)
 ./build.sh clean        # Clean build artifacts
 ```
 
@@ -92,6 +93,15 @@ GOOS=windows GOARCH=amd64 go build -o build/powerbeacon-agent-windows-amd64.exe 
 GOOS=darwin GOARCH=amd64 go build -o build/powerbeacon-agent-darwin-amd64 ./cmd/agent
 GOOS=darwin GOARCH=arm64 go build -o build/powerbeacon-agent-darwin-arm64 ./cmd/agent
 ```
+
+### Docker Buildx-oriented build script usage
+
+```bash
+TARGETOS=linux TARGETARCH=amd64 ./build.sh docker-cross
+TARGETOS=linux TARGETARCH=arm64 ./build.sh docker-cross
+```
+
+This target is primarily used by the Dockerfile during `docker buildx build` so each platform receives a correctly compiled static agent binary.
 
 ## Running
 

--- a/agent/DOCKER_INTEGRATION.md
+++ b/agent/DOCKER_INTEGRATION.md
@@ -4,12 +4,15 @@ This directory contains an example of how to run the PowerBeacon agent alongside
 
 ## Important Note
 
-**The agent MUST run on the host machine, NOT in a Docker container.**
+The recommended production setup is to run the agent directly on the host machine.
 
-This is because:
+Containerized agent deployment is supported on Linux hosts only when `network_mode: host` is used.
+
+Reasoning:
 - Wake-on-LAN requires Layer 2 broadcast packets
-- Docker's networking stack on Windows/macOS cannot send broadcast packets to the host network
-- The agent needs direct access to physical network interfaces
+- Docker bridge networking cannot broadcast to the physical LAN
+- Docker Desktop on Windows/macOS cannot provide reliable host-LAN broadcast for this use case
+- The agent needs direct access to physical network interfaces or host network namespace
 
 ## Development Setup
 
@@ -44,6 +47,22 @@ go build -o powerbeacon-agent ./cmd/agent
 # Windows
 .\powerbeacon-agent.exe -backend http://localhost:8000
 ```
+
+### Optional: Run the Agent in Docker (Linux only)
+
+```yaml
+powerbeacon-agent:
+  image: kotsiossp97/powerbeacon-agent:latest
+  container_name: powerbeacon-agent
+  environment:
+    BACKEND_URL: http://localhost:8000
+    AGENT_ADVERTISE_IP: ${AGENT_ADVERTISE_IP:-}
+  network_mode: host
+  depends_on:
+    - powerbeacon
+```
+
+Use `AGENT_ADVERTISE_IP` when the Linux host has multiple interfaces so the backend stores a reachable LAN IP.
 
 The agent will:
 1. Detect network interfaces

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,0 +1,45 @@
+# ────────────────────────────────────────────────────────────────
+# Stage 1: Build
+# ────────────────────────────────────────────────────────────────
+FROM golang:1.26 AS builder
+
+# Build arguments for cross-compilation
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /app
+
+COPY ./go.mod ./
+COPY ./go.sum ./
+
+RUN go mod download
+
+# Copy the rest of the source
+COPY . .
+
+# Build static binary for target architecture using build script
+RUN bash ./build.sh docker-cross
+
+# ────────────────────────────────────────────────────────────────
+# Stage 2: Runtime image
+# ────────────────────────────────────────────────────────────────
+FROM scratch
+
+# Copy CA certificates from builder so the agent can make HTTPS
+# calls to the backend if it is behind TLS.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy the binary
+COPY --from=builder /app/build/powerbeacon-agent /powerbeacon-agent
+
+# Document the port the agent listens on (informational only,
+# has no effect when network_mode: host is used)
+EXPOSE 18080
+
+# Environment variable defaults — all overridable at runtime
+ENV BACKEND_URL=http://localhost:8000
+ENV AGENT_PORT=18080
+ENV AGENT_BIND=0.0.0.0
+ENV AGENT_ADVERTISE_IP=
+
+ENTRYPOINT ["/powerbeacon-agent"]

--- a/agent/README.md
+++ b/agent/README.md
@@ -50,6 +50,32 @@ GOOS=darwin GOARCH=amd64 go build -o build/powerbeacon-agent-darwin-amd64 ./cmd/
 GOOS=darwin GOARCH=arm64 go build -o build/powerbeacon-agent-darwin-arm64 ./cmd/agent
 ```
 
+### Build script targets
+
+```bash
+./build.sh linux
+./build.sh linux-arm64
+./build.sh windows
+./build.sh darwin
+./build.sh docker-cross
+```
+
+The `docker-cross` target is intended for Docker Buildx flows. It reads `TARGETOS` and `TARGETARCH` from the environment and compiles a static binary to `build/powerbeacon-agent`.
+
+### Docker image (multi-arch)
+
+Build and push a multi-platform image:
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t kotsiossp97/powerbeacon-agent:latest \
+  --push \
+  .
+```
+
+The Dockerfile passes Buildx target platform values into the build script (`TARGETOS`/`TARGETARCH`), and the script builds the matching architecture binary for each platform.
+
 ## Installation
 
 The agent should be installed as a system service. Installation scripts are provided by the PowerBeacon backend.

--- a/agent/build.sh
+++ b/agent/build.sh
@@ -15,6 +15,18 @@ build_linux() {
     GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.Version=$VERSION" -o "$BUILD_DIR/$BINARY_NAME-linux-amd64" ./cmd/agent
 }
 
+build_docker_cross() {
+    # Called from Docker buildx for cross-platform builds
+    # TARGETOS and TARGETARCH are passed as environment variables
+    local TARGET_OS="${TARGETOS:?TARGETOS is not set}"
+    local TARGET_ARCH="${TARGETARCH:?TARGETARCH is not set}"
+    echo "Building for Docker Cross-Platform (${TARGET_OS}/${TARGET_ARCH})..."
+    CGO_ENABLED=0 GOOS="${TARGET_OS}" GOARCH="${TARGET_ARCH}" go build \
+        -ldflags "-s -w -X main.Version=$VERSION" \
+        -o "$BUILD_DIR/powerbeacon-agent" \
+        ./cmd/agent
+}
+
 build_linux_arm64() {
     echo "Building for Linux (arm64)..."
     GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X main.Version=$VERSION" -o "$BUILD_DIR/$BINARY_NAME-linux-arm64" ./cmd/agent
@@ -84,6 +96,10 @@ case "$TARGET" in
     linux)
         ensure_build_dir
         build_linux
+    ;;
+    docker-cross)
+        ensure_build_dir
+        build_docker_cross
     ;;
     linux-arm64)
         ensure_build_dir

--- a/docs/docs/deployment/docker.md
+++ b/docs/docs/deployment/docker.md
@@ -75,3 +75,30 @@ as it provides a good balance between ease of use and flexibility. It is also th
       -e JWT_SECRET=your-secret-key-change-in-production \
       powerbeacon:latest
     ```
+
+## Optional Agent Container (Linux only)
+
+If you want to run the agent in Docker, use a Linux host and `network_mode: host`.
+
+Why this is required:
+
+- Wake-on-LAN uses UDP broadcast to the physical LAN.
+- Docker bridge networking cannot broadcast to the host LAN segment.
+- Docker Desktop (Windows/macOS) is not suitable for this containerized WOL path.
+
+Example service:
+
+```yaml
+services:
+  powerbeacon-agent:
+    image: kotsiossp97/powerbeacon-agent:latest
+    container_name: powerbeacon-agent
+    environment:
+      BACKEND_URL: http://localhost:8000
+      AGENT_ADVERTISE_IP: ${AGENT_ADVERTISE_IP:-}
+    network_mode: host
+    depends_on:
+      - powerbeacon
+```
+
+If the host has multiple interfaces (for example Ethernet and VPN), set `AGENT_ADVERTISE_IP` so the backend stores the correct reachable LAN IP for dispatch.

--- a/docs/docs/setup/docker.md
+++ b/docs/docs/setup/docker.md
@@ -130,6 +130,8 @@ Expected services:
 
 On Docker Desktop (Windows/macOS), direct UDP broadcast from containers is unreliable for LAN wake. PowerBeacon solves this with agents: install the lightweight `powerbeacon-agent` on a Linux machine in the target LAN, register it in the UI, and assign it to your devices. The backend dispatches WOL packets through the agent over HTTP instead of broadcasting directly.
 
+On Linux hosts, an optional containerized agent deployment is supported when `network_mode: host` is used for the agent container.
+
 !!! note "Recommended production pattern"
     Keep backend/frontend/db containerized, and deploy one or more agents close to the target subnets.
 

--- a/example.compose.yml
+++ b/example.compose.yml
@@ -30,6 +30,30 @@ services:
     networks:
       - powerbeacon_network
 
+  # ────────────────────────────────────────────────────────────────────────────
+  # Agent (optional — only when user wants to run the agent in Docker -- ONLY FOR LINUX)
+  #
+  # IMPORTANT: network_mode: host is REQUIRED. The agent sends UDP broadcast
+  # packets to wake devices. Docker's bridge network cannot broadcast to the
+  # physical LAN, so the container must share the host's network namespace.
+  #
+  # CONSEQUENCE of network_mode: host:
+  #   - The agent is reachable at the host's own IP on port 18080
+  #   - This works on Linux only. Not supported on Docker Desktop (Windows/macOS).
+  #
+  # Set AGENT_ADVERTISE_IP if the host has multiple interfaces (e.g., eth0 + a
+  # VPN adapter) so the backend registers the correct LAN IP for dispatch.
+  # ────────────────────────────────────────────────────────────────────────────
+  # powerbeacon-agent:
+  #   image: kotsiossp97/powerbeacon-agent:latest
+  #   container_name: powerbeacon-agent
+  #   environment:
+  #     BACKEND_URL: http://localhost:8000
+  #     AGENT_ADVERTISE_IP: ${AGENT_ADVERTISE_IP:-} # Optional: set if host has multiple interfaces to ensure correct IP is registered in backend
+  #   network_mode: host # Required
+  #   depends_on:
+  #     - powerbeacon
+
 volumes:
   powerbeacon_data:
 


### PR DESCRIPTION
## Description
This pull request introduces official support for building, publishing, and documenting a dedicated multi-architecture Docker image for the PowerBeacon agent. It adds a new CI/CD workflow that automatically builds and pushes the agent image on tag pushes when there are changes in the `agent/` directory. The documentation is updated to explain how to use the new agent image, including platform limitations and deployment patterns. The agent's build scripts and Dockerfile are refactored to support cross-platform builds via Docker Buildx.

**CI/CD and Build System Enhancements:**

* Added `.github/workflows/agent-image.yml` GitHub Actions workflow to automatically build and publish the agent Docker image for `linux/amd64` and `linux/arm64` to both GitHub Container Registry and Docker Hub, triggered on tag pushes and only when `agent/` changes are detected.
* Refactored `agent/build.sh` to add a `docker-cross` target for Docker Buildx cross-platform builds, reading `TARGETOS` and `TARGETARCH` from the environment, and updated script usage in documentation. [[1]](diffhunk://#diff-c853639e8a965073845c841612123f6ad976b947b433d758d6af6beccba11707R18-R29) [[2]](diffhunk://#diff-c853639e8a965073845c841612123f6ad976b947b433d758d6af6beccba11707R100-R103) [[3]](diffhunk://#diff-ec1c674f8acb5991d939d8e10561c06a1b73190d98ef17a13c5cc1c9659626feR69) [[4]](diffhunk://#diff-ec1c674f8acb5991d939d8e10561c06a1b73190d98ef17a13c5cc1c9659626feR97-R105) [[5]](diffhunk://#diff-927132d37d406f802d111f09043681798df707c14fff06e66270a4558049cb4aR53-R78)
* Added a multi-stage `agent/Dockerfile` that builds a static agent binary for the target architecture and creates a minimal runtime image, supporting multi-arch builds and secure HTTPS communication.

**Documentation Updates:**

* Updated `README.md`, `agent/README.md`, and `agent/DEVELOPMENT.md` to document the new agent image, build process, and usage patterns, including badges for the new workflow and multi-arch build instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R88-R94) [[3]](diffhunk://#diff-927132d37d406f802d111f09043681798df707c14fff06e66270a4558049cb4aR53-R78) [[4]](diffhunk://#diff-ec1c674f8acb5991d939d8e10561c06a1b73190d98ef17a13c5cc1c9659626feR69) [[5]](diffhunk://#diff-ec1c674f8acb5991d939d8e10561c06a1b73190d98ef17a13c5cc1c9659626feR97-R105)
* Clarified in `agent/DOCKER_INTEGRATION.md`, `docs/docs/deployment/docker.md`, and `docs/docs/setup/docker.md` that containerized agent deployment is supported only on Linux hosts with `network_mode: host`, and explained the technical reasons and configuration. [[1]](diffhunk://#diff-9fc0194277cce61de71f3f99d1aa55e99d0a67524ca876684893e00c7c19016fL7-R15) [[2]](diffhunk://#diff-9fc0194277cce61de71f3f99d1aa55e99d0a67524ca876684893e00c7c19016fR51-R66) [[3]](diffhunk://#diff-6aa75539e8177d8aae3fdaa129536f20de939fa2fb834c1c73c16aed4cca50cdR78-R104) [[4]](diffhunk://#diff-1732d6b2772230a0124a09b833de84f1537e2af40059f01e1a56e099e8f95c0eR133-R134)

**Example and Compose File Changes:**

* Added commented-out example service for the agent container with proper environment and networking settings in `example.compose.yml`, including detailed notes on platform and networking requirements.


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] Local backend tests (`uv run pytest`, `uv run ruff check .`)
- [x] Local agent tests (`make test`)
- [] Local frontend tests/lint (`npm run lint`)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings