### PR TITLE
fix: Unavailable app metadata due to GitHub API rate limit

### DIFF
--- a/backend/powerbeacon/services/app_metadata.py
+++ b/backend/powerbeacon/services/app_metadata.py
@@ -14,7 +14,8 @@ from powerbeacon.core import settings
 GITHUB_REPO = "kotsiossp97/powerbeacon"
 GITHUB_API_BASE = "https://api.github.com"
 REPO_URL = f"https://github.com/{GITHUB_REPO}"
-CACHE_TTL = timedelta(minutes=15)
+METADATA_CACHE_TTL = timedelta(hours=6)
+CONTRIBUTORS_CACHE_TTL = timedelta(hours=24)
 
 
 @dataclass(slots=True)
@@ -32,6 +33,8 @@ class AppMetadata:
 class _CacheState:
     value: AppMetadata | None = None
     expires_at: datetime | None = None
+    contributors: list[dict[str, str | int | None]] | None = None
+    contributors_expires_at: datetime | None = None
 
 
 _cache = _CacheState()
@@ -119,20 +122,35 @@ def _fetch_contributors() -> list[dict[str, str | int | None]]:
 
 def get_app_metadata() -> AppMetadata:
     now = datetime.now(UTC)
+    stale_cache: AppMetadata | None = None
+    cached_contributors: list[dict[str, str | int | None]] | None = None
+    refresh_contributors = True
 
     with _cache_lock:
+        stale_cache = _cache.value
         if _cache.value and _cache.expires_at and now < _cache.expires_at:
             return _cache.value
+        cached_contributors = _cache.contributors
+        refresh_contributors = not (
+            _cache.contributors is not None
+            and _cache.contributors_expires_at
+            and now < _cache.contributors_expires_at
+        )
 
     latest_version: str | None = None
     release_url = REPO_URL
-    contributors: list[dict[str, str | int | None]] = []
+    contributors: list[dict[str, str | int | None]] = cached_contributors or []
 
     try:
         latest_version, release_url = _fetch_latest_release()
-        contributors = _fetch_contributors()
+        if refresh_contributors:
+            contributors = _fetch_contributors()
     except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError):
-        pass
+        if stale_cache:
+            # Keep serving stale data when GitHub API is unavailable or rate-limited.
+            with _cache_lock:
+                _cache.expires_at = now + METADATA_CACHE_TTL
+            return stale_cache
 
     metadata = AppMetadata(
         current_version=settings.app_version,
@@ -146,6 +164,8 @@ def get_app_metadata() -> AppMetadata:
 
     with _cache_lock:
         _cache.value = metadata
-        _cache.expires_at = now + CACHE_TTL
+        _cache.expires_at = now + METADATA_CACHE_TTL
+        _cache.contributors = contributors
+        _cache.contributors_expires_at = now + CONTRIBUTORS_CACHE_TTL
 
     return metadata


### PR DESCRIPTION
## Description
This pull request improves the caching strategy for application metadata and contributors in the `app_metadata.py` service. The main changes separate cache lifetimes for metadata and contributors, introduce more robust error handling to serve stale data if the GitHub API is unavailable, and refactor the cache state to support these enhancements.

**Caching improvements:**

* Introduced separate cache time-to-live (TTL) values: `METADATA_CACHE_TTL` (6 hours) for general metadata and `CONTRIBUTORS_CACHE_TTL` (24 hours) for contributors, replacing the previous single `CACHE_TTL`.
* Extended the `_CacheState` dataclass to include cached contributors and their expiration time, allowing independent refresh of contributors data.

**Error handling and data freshness:**

* Updated `get_app_metadata()` to serve stale cached metadata if the GitHub API is unavailable or rate-limited, improving reliability during outages.
* Refactored logic to refresh contributors only when their cache has expired, while still using the latest cached contributors if available.

**Cache update logic:**

* On successful metadata fetch, now updates both metadata and contributors in the cache, with their respective expiration times.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] Local backend tests (`uv run pytest`, `uv run ruff check .`)
- [ ] Local agent tests (`make test`)
- [x] Local frontend tests/lint (`npm run lint`)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings